### PR TITLE
[Fix] Update rotate-screen prop-types with class-name

### DIFF
--- a/src/components/RotateScreen/RotateScreen.js
+++ b/src/components/RotateScreen/RotateScreen.js
@@ -78,12 +78,14 @@ export default class RotateScreen extends PureComponent {
 }
 
 RotateScreen.propTypes = checkProps({
+  className: PropTypes.string,
   copy: PropTypes.string,
   iconSrc: PropTypes.string,
   iconAlt: PropTypes.string
 });
 
 RotateScreen.defaultProps = {
+  className: '',
   copy: 'Please rotate your device into portrait mode.',
   iconAlt: 'Please rotate your device'
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [ ] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description
A warning appeared in the console caused by `RotateScreen` not having `className` as a `propTypes`.

![image](https://user-images.githubusercontent.com/5182704/70154424-3bf0e980-168f-11ea-82c1-09aeb8b2c198.png)

## Solution Description
Update `RotateScreen` `propTypes` with `className`.

## Side Effects, Risks, Impact
This shouldn't break anything.

- [ ] N/A

**Aditional comments:**
